### PR TITLE
fix, docs: JWT 필터 예외 경로 조정, Swagger 설명 추가

### DIFF
--- a/src/main/java/Devroup/hidaddy/controller/AuthController.java
+++ b/src/main/java/Devroup/hidaddy/controller/AuthController.java
@@ -23,7 +23,12 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 import java.util.Map;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(
+        name = "Authentication",
+        description = "Access/Refresh Token 발급 및 갱신, 로그아웃, 회원탈퇴 등 인증 관련 API"
+)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")

--- a/src/main/java/Devroup/hidaddy/controller/UserController.java
+++ b/src/main/java/Devroup/hidaddy/controller/UserController.java
@@ -10,7 +10,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(
+        name = "User",
+        description = "회원 정보, 아기 등록 및 선택 등 사용자 관련 API"
+)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user")

--- a/src/main/java/Devroup/hidaddy/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/Devroup/hidaddy/jwt/JwtAuthenticationFilter.java
@@ -85,7 +85,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private boolean isPublicPath(String path) {
         return path.equals("/") ||
                 path.startsWith("/api/login") ||
-                path.startsWith("/api/auth/oauth2") ||
+                path.startsWith("/api/auth/tokens") ||
+                path.startsWith("/api/auth/renew") ||
                 path.startsWith("/auth") ||
                 path.startsWith("/oauth2") ||
                 path.startsWith("/css") ||


### PR DESCRIPTION
- isPublicPath() 메서드에서 /api/auth/oauth2 경로를 예외에서 제거, /api/auth/tokens 및 /api/auth/renew 경로를 추가
- AuthController와 UserController에 @Tag 어노테이션을 추가해 API 그룹과 설명을 제공