### PR TITLE
feat: 소셜 로그인 OAuth2 콜백 엔드포인트 구현 및 앱 딥링크 리디렉션 처리

### DIFF
--- a/src/main/java/Devroup/hidaddy/controller/OAuth2CallbackController.java
+++ b/src/main/java/Devroup/hidaddy/controller/OAuth2CallbackController.java
@@ -1,0 +1,50 @@
+package Devroup.hidaddy.controller;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@Slf4j
+@RestController
+@RequestMapping("/login/oauth2/code")
+@RequiredArgsConstructor
+public class OAuth2CallbackController {
+
+    @GetMapping("/kakao")
+    public void redirectKakao(
+            @Parameter(description = "카카오 인가 코드", required = true)
+            @RequestParam("code") String code,
+            HttpServletResponse response
+    ) throws IOException {
+        redirectToApp("kakao", code, response);
+    }
+
+    @GetMapping("/naver")
+    public void redirectNaver(
+            @Parameter(description = "네이버 인가 코드", required = true)
+            @RequestParam("code") String code,
+            HttpServletResponse response
+    ) throws IOException {
+        redirectToApp("naver", code, response);
+    }
+
+    @GetMapping("/google")
+    public void redirectGoogle(
+            @Parameter(description = "구글 인가 코드", required = true)
+            @RequestParam("code") String code,
+            HttpServletResponse response
+    ) throws IOException {
+        redirectToApp("google", code, response);
+    }
+
+    private void redirectToApp(String provider, String code, HttpServletResponse response) throws IOException {
+        log.info("📥 [{} 콜백] 인가 코드 수신: {}", provider.toUpperCase(), code);
+        String redirectUrl = "hidaddy://callback?provider=" + provider + "&code=" + code;
+        log.info("🔀 앱으로 리디렉션: {}", redirectUrl);
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/src/main/java/Devroup/hidaddy/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/Devroup/hidaddy/jwt/JwtAuthenticationFilter.java
@@ -85,6 +85,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private boolean isPublicPath(String path) {
         return path.equals("/") ||
                 path.startsWith("/api/login") ||
+                path.startsWith("/login/oauth2/code") ||
                 path.startsWith("/api/auth/tokens") ||
                 path.startsWith("/api/auth/renew") ||
                 path.startsWith("/auth") ||


### PR DESCRIPTION
- /login/oauth2/code/{provider} 엔드포인트 구현 (Google, Kakao, Naver)
- 소셜 인증 후 전달된 code 파라미터를 파싱하여 앱 딥링크로 리디렉션 (형식: hidaddy://callback?provider={provider}&code={code})
- Spring Security의 AuthenticationSuccessHandler 미작동 이슈로 직접 처리