### PR TITLE
refactor: 아기 그룹 단위 아기 관리 기능 전체 리팩토링

### DIFF
--- a/src/main/java/Devroup/hidaddy/controller/UserController.java
+++ b/src/main/java/Devroup/hidaddy/controller/UserController.java
@@ -88,7 +88,7 @@ public class UserController {
             return ResponseEntity.status(401).build();
         }
 
-        List<BabyResponse> babies = babyService.registerBaby(requestDto, userDetails.getUser());
+        List<BabyResponse> babies = babyService.registerBabyGroupTutorial(requestDto, userDetails.getUser());
         BabyRegisterResponse response = new BabyRegisterResponse(requestDto.getUserName(), babies);
         return ResponseEntity.ok(response);
     }
@@ -131,36 +131,36 @@ public class UserController {
         return ResponseEntity.ok(selectedBabyInfo);
     }
 
-    // 아기 수정 (이름, 날짜, 이미지)
-    @PatchMapping("/baby/{babyId}")
+    // 아기 수정 (이름, 날짜)
+    @PatchMapping("/baby/{groupId}")
     @Operation(summary = "아기 정보 수정", description = "지정된 아기의 이름, 출산 예정일 등을 수정합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 (로그인 필요)")
     })
-    public ResponseEntity<BabyResponse> updateBaby(
-            @PathVariable Long babyId,
-            @RequestBody BabyUpdateRequest dto,
+    public ResponseEntity<List<BabyResponse>> updateBaby(
+            @PathVariable Long groupId,
+            @RequestBody List<BabyUpdateRequest> updates,
             @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
-        if (userDetails == null) {
-            return ResponseEntity.status(401).build();
-        }
-
-        BabyResponse response = babyService.updateBaby(userDetails.getUser(), babyId, dto);
+        if (userDetails == null) return ResponseEntity.status(401).build();
+        List<BabyResponse> response = babyService.updateBabyGroup(groupId, updates);
         return ResponseEntity.ok(response);
     }
 
 
     // 아기 삭제
     @Operation(summary = "아기 삭제", description = "지정된 아기 정보를 삭제합니다.")
-    @DeleteMapping("/baby/{babyId}")
-    public ResponseEntity<MessageResponse> deleteBaby(@PathVariable Long babyId,
-                                             @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    @DeleteMapping("/baby/{groupId}")
+    public ResponseEntity<MessageResponse> deleteBabyp(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
         if (userDetails == null) return ResponseEntity.status(401).build();
-        babyService.deleteBaby(userDetails.getUser(), babyId);
-        return ResponseEntity.ok(new MessageResponse("아기 삭제 완료"));
+
+        babyService.deleteBabyGroup(userDetails.getUser(), groupId);
+        return ResponseEntity.ok(new MessageResponse("아기 그룹 삭제 완료"));
     }
 
     @Operation(summary = "아기 정보 등록", description = "태명과 출산 예정일만 입력하여 아기를 등록합니다.")
@@ -178,7 +178,7 @@ public class UserController {
             return ResponseEntity.status(401).build();
         }
 
-        List<BabyResponse> response = babyService.registerBabyBasic(request.getBabies(), userDetails.getUser());
+        List<BabyResponse> response = babyService.registerBabyGroup(request.getBabies(), userDetails.getUser());
         return ResponseEntity.ok(response);
     }
 
@@ -189,15 +189,17 @@ public class UserController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 (로그인 필요)"),
             @ApiResponse(responseCode = "404", description = "해당 아기 정보를 찾을 수 없음")
     })
-    @PatchMapping("/select-baby/{babyId}")
-    public ResponseEntity<BabyResponse> selectBaby(@PathVariable Long babyId,
-                                        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    @PatchMapping("/select-baby-group/{groupId}")
+    public ResponseEntity<SelectedBabyResponse> selectBabyGroup(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
         if (userDetails == null) {
             return ResponseEntity.status(401).build();
         }
 
-        BabyResponse response = userService.changeSelectedBaby(userDetails.getUser(), babyId);
-        return ResponseEntity.ok(response);
+        SelectedBabyResponse selectedBabyResponse = userService.changeSelectedBabyGroup(userDetails.getUser(), groupId);
+        return ResponseEntity.ok(selectedBabyResponse);
     }
 
     @PatchMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/Devroup/hidaddy/dto/user/BabyResponse.java
+++ b/src/main/java/Devroup/hidaddy/dto/user/BabyResponse.java
@@ -12,10 +12,14 @@ public class BabyResponse {
     private String name;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") // 날짜 포맷 지정
     private LocalDate dueDate;
+    private Long babyGroupId;
+    private boolean isTwin;
 
-    public BabyResponse(Baby baby) {
+    public BabyResponse(Baby baby, boolean isTwin) {
         this.id = baby.getId();
         this.name = baby.getName();
         this.dueDate = baby.getDueDate().toLocalDate();
+        this.babyGroupId = baby.getBabyGroup().getId();
+        this.isTwin = isTwin;
     }
 }

--- a/src/main/java/Devroup/hidaddy/dto/user/SelectedBabyResponse.java
+++ b/src/main/java/Devroup/hidaddy/dto/user/SelectedBabyResponse.java
@@ -4,31 +4,23 @@ import Devroup.hidaddy.entity.Baby;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 @Getter
 @Builder
 @AllArgsConstructor
 public class SelectedBabyResponse {
-    private Long id;
-    private String name;
-    private String dDay;
-    private String babyImageUrl;
+    private List<BabyResponse> babies;
     private String comment;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") // 날짜 포맷 지정
-    private LocalDate dueDate;
+    private String dDay;
 
     public static SelectedBabyResponse from(Baby baby, String comment) {
         return SelectedBabyResponse.builder()
-                .id(baby.getId())
-                .name(baby.getName())
                 .dDay(formatDday(baby.getDueDate().toLocalDate()))
-                .babyImageUrl(baby.getBabyImageUrl())
                 .comment(comment)
-                .dueDate(baby.getDueDate().toLocalDate())
                 .build();
     }
 
@@ -36,7 +28,6 @@ public class SelectedBabyResponse {
         int diff = (int) ChronoUnit.DAYS.between(LocalDate.now(), date);
         if (diff == 0)
             return "D-day";
-
         return (diff > 0) ? "D-" + diff : "D+" + Math.abs(diff);
     }
-} 
+}

--- a/src/main/java/Devroup/hidaddy/entity/Baby.java
+++ b/src/main/java/Devroup/hidaddy/entity/Baby.java
@@ -35,4 +35,8 @@ public class Baby {
     }
 
     private String babyImageUrl;
+
+    @ManyToOne
+    @JoinColumn(name = "baby_group_id")
+    private BabyGroup babyGroup;  // null 가능 (단일 아이인 경우)
 }

--- a/src/main/java/Devroup/hidaddy/entity/BabyGroup.java
+++ b/src/main/java/Devroup/hidaddy/entity/BabyGroup.java
@@ -1,0 +1,23 @@
+package Devroup.hidaddy.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class BabyGroup {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @OneToMany(mappedBy = "babyGroup")
+    private List<Baby> babies = new ArrayList<>();
+}

--- a/src/main/java/Devroup/hidaddy/repository/user/BabyGroupRepository.java
+++ b/src/main/java/Devroup/hidaddy/repository/user/BabyGroupRepository.java
@@ -1,0 +1,7 @@
+package Devroup.hidaddy.repository.user;
+
+import Devroup.hidaddy.entity.BabyGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BabyGroupRepository extends JpaRepository<BabyGroup, Long> {
+}

--- a/src/main/java/Devroup/hidaddy/repository/user/BabyRepository.java
+++ b/src/main/java/Devroup/hidaddy/repository/user/BabyRepository.java
@@ -17,4 +17,6 @@ public interface BabyRepository extends JpaRepository<Baby, Long> {
     Optional<Baby> findByIdAndUserId(Long babyId, Long userId);
 
     Optional<Baby> findById(Long babyId);
+
+    List<Baby> findAllByUser(User user);
 }

--- a/src/main/java/Devroup/hidaddy/service/BabyService.java
+++ b/src/main/java/Devroup/hidaddy/service/BabyService.java
@@ -5,7 +5,9 @@ import Devroup.hidaddy.dto.user.BabyRegisterRequest;
 import Devroup.hidaddy.dto.user.BabyResponse;
 import Devroup.hidaddy.dto.user.BabyUpdateRequest;
 import Devroup.hidaddy.entity.Baby;
+import Devroup.hidaddy.entity.BabyGroup;
 import Devroup.hidaddy.entity.User;
+import Devroup.hidaddy.repository.user.BabyGroupRepository;
 import Devroup.hidaddy.repository.user.BabyRepository;
 import Devroup.hidaddy.repository.user.UserRepository;
 import Devroup.hidaddy.util.S3Uploader;
@@ -26,107 +28,122 @@ public class BabyService {
 
     private final UserRepository userRepository;
     private final BabyRepository babyRepository;
+    private final BabyGroupRepository babyGroupRepository;
     private final S3Uploader s3Uploader;
 
     @Value("${cloudfront.domain}")
     private String cloudFrontDomain;
 
-    // 아기 리스트 조회
-    public List<BabyResponse> getBabies(User user) {
-        List<Baby> babies = babyRepository.findByUser(user);
-        return babies.stream()
-                .map(BabyResponse::new)
-                .toList();
-    }
-
-    // 아기 수정
-    @Transactional
-    public BabyResponse updateBaby(User user, Long babyId, BabyUpdateRequest dto) {
-        Baby baby = babyRepository.findById(babyId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 아기를 찾을 수 없습니다."));
-
-        if (!baby.getUser().getId().equals(user.getId())) {
-            throw new IllegalArgumentException("해당 아기에 대한 수정 권한이 없습니다.");
-        }
-
-        if (dto.getName() != null) baby.setName(dto.getName());
-        if (dto.getDueDate() != null) baby.setDueDate(dto.getDueDate().atStartOfDay());
-
-        return new BabyResponse(babyRepository.save(baby));
-    }
-
-    // 아기 삭제
-    public void deleteBaby(User user, Long babyId) {
-        Baby baby = babyRepository.findById(babyId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 아기를 찾을 수 없습니다."));
-        if (!baby.getUser().getId().equals(user.getId())) {
-            throw new IllegalArgumentException("해당 아기에 대한 삭제 권한이 없습니다.");
-        }
-        babyRepository.delete(baby);
-    }
-
-    public List<BabyResponse> registerBabyBasic(List<BabyRegisterRequest> babies, User user) {
-
-        List<BabyResponse> responses = new ArrayList<>();
-
-        for (int i = 0; i < babies.size(); i++) {
-            BabyRegisterRequest dto = babies.get(i);
-            LocalDateTime parsedDueDate = parseDueDate(dto.getDueDate());
-
-            Baby baby = Baby.builder()
-                    .name(dto.getBabyName())
-                    .dueDate(parsedDueDate)
-                    .user(user)
-                    .build();
-
-            babyRepository.save(baby);
-            responses.add(new BabyResponse(baby));
-
-            // 첫 번째 아기를 선택된 아기로 설정
-            if (i == 0) {
-                user.setSelectedBabyId(baby.getId());
-            }
-        }
-
-        userRepository.save(user); // 변경된 selectedBabyId 저장
-
-        return responses;
-    }
-
-    public List<BabyResponse> registerBaby(BabyRegisterListRequest request, User user) {
-        List<BabyRegisterRequest> babyList = request.getBabies();
-
-        if (babyList == null || babyList.isEmpty()) {
+    // 튜토리얼 단계에서 아기 그룹 등록 (User 이름까지 함께 등록)
+    public List<BabyResponse> registerBabyGroupTutorial(BabyRegisterListRequest request, User user) {
+        List<BabyRegisterRequest> babies = request.getBabies();
+        if (babies == null || babies.isEmpty()) {
             throw new IllegalArgumentException("최소 한 명 이상의 아기 정보가 필요합니다.");
         }
 
-        // 유저 이름 설정
         user.setName(request.getUserName());
+        userRepository.save(user);
 
-        List<BabyResponse> responses = new ArrayList<>();
+        BabyGroup babyGroup = new BabyGroup();
+        babyGroupRepository.save(babyGroup);
 
-        for (int i = 0; i < babyList.size(); i++) {
-            BabyRegisterRequest dto = babyList.get(i);
+        List<Baby> babyEntities = new ArrayList<>();
+        for (BabyRegisterRequest dto : babies) {
             LocalDateTime parsedDueDate = parseDueDate(dto.getDueDate());
 
             Baby baby = Baby.builder()
                     .name(dto.getBabyName())
                     .dueDate(parsedDueDate)
                     .user(user)
+                    .babyGroup(babyGroup)
                     .build();
 
-            babyRepository.save(baby);
-            responses.add(new BabyResponse(baby));
-
-            // 첫 번째 아기를 선택된 아기로 지정
-            if (i == 0) {
-                user.setSelectedBabyId(baby.getId());
-            }
+            babyEntities.add(baby);
         }
 
-        userRepository.save(user); // 선택된 아기 ID 저장
+        babyRepository.saveAll(babyEntities);
+        user.setSelectedBabyId(babyGroup.getId());
+        userRepository.save(user);
 
-        return responses;
+        return convertToResponses(babyEntities, babyEntities.size() > 1);
+    }
+
+    // 아기 그룹 등록 (1명 or 2명 모두 이 메서드 사용)
+    public List<BabyResponse> registerBabyGroup(List<BabyRegisterRequest> babies, User user) {
+        if (babies == null || babies.isEmpty()) {
+            throw new IllegalArgumentException("최소 한 명 이상의 아기 정보가 필요합니다.");
+        }
+
+        BabyGroup babyGroup = new BabyGroup();
+        babyGroupRepository.save(babyGroup);
+
+        List<Baby> babyEntities = new ArrayList<>();
+        for (BabyRegisterRequest dto : babies) {
+            LocalDateTime parsedDueDate = parseDueDate(dto.getDueDate());
+
+            Baby baby = Baby.builder()
+                    .name(dto.getBabyName())
+                    .dueDate(parsedDueDate)
+                    .user(user)
+                    .babyGroup(babyGroup)
+                    .build();
+
+            babyEntities.add(baby);
+        }
+
+        babyRepository.saveAll(babyEntities);
+        user.setSelectedBabyId(babyGroup.getId());
+        userRepository.save(user);
+
+        return convertToResponses(babyEntities, babyEntities.size() > 1);
+    }
+
+    // 아기 그룹 전체 조회
+    public List<BabyResponse> getBabies(User user) {
+        List<Baby> babies = babyRepository.findAllByUser(user);
+
+        return babies.stream()
+                .map(baby -> {
+                    int groupSize = baby.getBabyGroup().getBabies().size(); // 해당 그룹 내 아기 수
+                    boolean isTwin = groupSize > 1;
+                    return new BabyResponse(baby, isTwin);
+                })
+                .toList();
+    }
+
+
+    // 아기 그룹 수정
+    @Transactional
+    public List<BabyResponse> updateBabyGroup(Long groupId, List<BabyUpdateRequest> updates) {
+        BabyGroup group = babyGroupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("선택된 아기 그룹을 찾을 수 없습니다."));
+
+        List<Baby> babies = group.getBabies();
+
+        for (int i = 0; i < updates.size(); i++) {
+            Baby baby = babies.get(i);
+            BabyUpdateRequest dto = updates.get(i);
+
+            if (dto.getName() != null) baby.setName(dto.getName());
+            if (dto.getDueDate() != null) baby.setDueDate(dto.getDueDate().atStartOfDay());
+        }
+
+        babyRepository.saveAll(babies);
+
+        return convertToResponses(babies, babies.size() > 1);
+    }
+
+    // 아기 그룹 삭제
+
+    public void deleteBabyGroup(User user, Long groupId) {
+        BabyGroup group = babyGroupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("선택된 아기 그룹을 찾을 수 없습니다."));
+
+        babyRepository.deleteAll(group.getBabies());
+        babyGroupRepository.delete(group);
+
+        user.setSelectedBabyId(null);
+        userRepository.save(user);
     }
 
     private LocalDateTime parseDueDate(String dueDate) {
@@ -135,5 +152,11 @@ public class BabyService {
         } catch (DateTimeParseException e) {
             throw new IllegalArgumentException("출산 예정일 형식이 올바르지 않습니다. yyyy-MM-dd 형식이어야 합니다.");
         }
+    }
+
+    private List<BabyResponse> convertToResponses(List<Baby> babies, boolean isTwin) {
+        return babies.stream()
+                .map(b -> new BabyResponse(b, isTwin))
+                .toList();
     }
 }


### PR DESCRIPTION
- BabyGroup 엔티티 도입 및 Baby와 1:N 관계 설정
- 모든 아기 등록 시 BabyGroup 자동 생성 및 할당
- User의 selectedBabyId를 selectedBabyGroupId로 해석하여 처리
- 아기 응답 DTO(BabyResponse)에 babyGroupId, isTwin 필드 추가
- PATCH /api/user/select-baby-group/{id} 응답에 선택된 그룹 아기 리스트 포함