### PR TITLE
feat: getBabies 응답을 groupid로 묶어 재구성

### DIFF
--- a/src/main/java/Devroup/hidaddy/controller/UserController.java
+++ b/src/main/java/Devroup/hidaddy/controller/UserController.java
@@ -101,14 +101,14 @@ public class UserController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 (로그인 필요)")
     })
     @GetMapping("/all-babies")
-    public ResponseEntity<List<BabyResponse>> getAllBabies(
+    public ResponseEntity<List<BabyGroupResponse>> getAllBabies(
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         if (userDetails == null) {
             return ResponseEntity.status(401).build();
         }
 
-        List<BabyResponse> babies = babyService.getBabies(userDetails.getUser());
+        List<BabyGroupResponse> babies = babyService.getBabies(userDetails.getUser());
         return ResponseEntity.ok(babies);
     }
 

--- a/src/main/java/Devroup/hidaddy/dto/user/BabyGroupResponse.java
+++ b/src/main/java/Devroup/hidaddy/dto/user/BabyGroupResponse.java
@@ -1,0 +1,16 @@
+package Devroup.hidaddy.dto.user;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class BabyGroupResponse {
+    private Long babyGroupId;
+    private boolean isTwin;
+    private LocalDate dueDate;  // <-- 추가
+    private List<BabyResponse> babies;
+}


### PR DESCRIPTION
- BabyService.getBabies() 응답을 babyGroupId 기준으로 그룹화
- 각 그룹에 대해 isTwin, dueDate, babies 필드 포함한 BabyGroupResponse DTO 도입
- dueDate는 그룹 내 첫 번째 아기의 dueDate 기준으로 설정
- 기존 BabyResponse 리스트 응답에서 구조 개선