### PR TITLE
fix: deleteBabyGroup의 LazyInitializationException 오류 해결

### DIFF
--- a/src/main/java/Devroup/hidaddy/service/BabyService.java
+++ b/src/main/java/Devroup/hidaddy/service/BabyService.java
@@ -154,9 +154,9 @@ public class BabyService {
     }
 
     // 아기 그룹 삭제
-
+    @Transactional
     public void deleteBabyGroup(User user, Long groupId) {
-        BabyGroup group = babyGroupRepository.findById(groupId)
+        BabyGroup group = babyGroupRepository.findWithBabiesById(groupId)
                 .orElseThrow(() -> new IllegalArgumentException("선택된 아기 그룹을 찾을 수 없습니다."));
 
         babyRepository.deleteAll(group.getBabies());


### PR DESCRIPTION
- babyGroupRepository.findWithBabiesById()를 통해 BabyGroup.babies를 fetch join으로 로딩
- deleteAll() 호출 전 Lazy 로딩 문제 해결
- deleteBabyGroup()에 @Transactional 추가로 세션 안정성 확보