### PR TITLE
fix: 아기 그룹 삭제 시 유저의 selectedBabyId 자동 재설정 로직 추가

### DIFF
--- a/src/main/java/Devroup/hidaddy/entity/BabyGroup.java
+++ b/src/main/java/Devroup/hidaddy/entity/BabyGroup.java
@@ -18,6 +18,6 @@ public class BabyGroup {
     @GeneratedValue
     private Long id;
 
-    @OneToMany(mappedBy = "babyGroup")
+    @OneToMany(mappedBy = "babyGroup", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Baby> babies = new ArrayList<>();
 }

--- a/src/main/java/Devroup/hidaddy/service/UserService.java
+++ b/src/main/java/Devroup/hidaddy/service/UserService.java
@@ -35,8 +35,9 @@ public class UserService {
     @Value("${cloudfront.domain}")
     private String cloudFrontDomain;
 
+    @Transactional
     public SelectedBabyResponse changeSelectedBabyGroup(User user, Long groupId) {
-        BabyGroup babyGroup = babyGroupRepository.findById(groupId)
+        BabyGroup babyGroup = babyGroupRepository.findWithBabiesById(groupId)
                 .orElseThrow(() -> new IllegalArgumentException("아기 그룹을 찾을 수 없습니다."));
 
         boolean isUserGroup = babyGroup.getBabies().stream()


### PR DESCRIPTION
- 아기 그룹 삭제 시 해당 그룹에 속한 아기들과 함께 삭제되도록 Cascade 설정 확인
- 삭제 이후 유저가 다른 아기를 보유한 경우 가장 최근 아기의 그룹으로 selectedBabyId 재설정
- 유저가 더 이상 아기를 보유하지 않은 경우 selectedBabyId를 null로 설정