### PR TITLE
feat: 유저 생성 시 할당되는 default 프로필 이미지 삭제

### DIFF
--- a/src/main/java/Devroup/hidaddy/service/UserService.java
+++ b/src/main/java/Devroup/hidaddy/service/UserService.java
@@ -98,7 +98,6 @@ public class UserService {
                     newUser.setPartnerPhone(partnerPhone);
                     newUser.setLoginType(loginType);
                     newUser.setSocialId(socialId);
-                    newUser.setProfileImageUrl(cloudFrontDomain + "/profile/default_image.svg");
                     isNewUser.set(true);
                     return userRepository.save(newUser);
                 });


### PR DESCRIPTION
- 신규 유저 생성 시 profileImageUrl 기본값(cloudFrontDomain + /profile/default_image.svg)을 설정하던 로직 제거
- 이제 회원가입 시 profileImageUrl은 null 상태로 저장됨