### PR TITLE
feat: 전화번호 API를 배우자 번호만 등록하도록 변경 + 주석/어노테이션 정리

### DIFF
--- a/src/main/java/Devroup/hidaddy/controller/AuthController.java
+++ b/src/main/java/Devroup/hidaddy/controller/AuthController.java
@@ -1,7 +1,7 @@
 package Devroup.hidaddy.controller;
 
 import Devroup.hidaddy.dto.auth.*;
-import Devroup.hidaddy.dto.user.MessageResponse;
+import Devroup.hidaddy.dto.user.ApiMessageResponse;
 import Devroup.hidaddy.entity.RefreshToken;
 import Devroup.hidaddy.entity.User;
 import Devroup.hidaddy.jwt.JwtUtil;
@@ -128,7 +128,7 @@ public class AuthController {
             description = "사용자의 Refresh Token을 삭제하여 세션을 무효화합니다."
     )
     @ApiResponse(responseCode = "200", description = "로그아웃 성공")
-    public ResponseEntity<MessageResponse> logout(
+    public ResponseEntity<ApiMessageResponse> logout(
             @Parameter(description = "로그아웃할 사용자의 Refresh Token")
             @RequestBody LogoutRequest logoutDto) {
         String refreshToken = (logoutDto != null) ? logoutDto.getRefreshToken() : null;
@@ -138,7 +138,7 @@ public class AuthController {
                     .ifPresent(refreshTokenRepository::delete);
         }
 
-        return ResponseEntity.ok(new MessageResponse("로그아웃 완료"));
+        return ResponseEntity.ok(new ApiMessageResponse("로그아웃 완료"));
     }
 
     // 현재 로그인한 사용자의 계정 및 관련 데이터(아기 그룹, Refresh Token 등)를 모두 삭제
@@ -149,12 +149,12 @@ public class AuthController {
             @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 (로그인 필요)")
     })
-    public ResponseEntity<MessageResponse> withdraw(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<ApiMessageResponse> withdraw(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         if (userDetails == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(new MessageResponse("인증되지 않은 사용자입니다."));
+                    .body(new ApiMessageResponse("인증되지 않은 사용자입니다."));
         }
         userService.deleteUser(userDetails.getUser());
-        return ResponseEntity.ok(new MessageResponse("회원 탈퇴가 완료되었습니다."));
+        return ResponseEntity.ok(new ApiMessageResponse("회원 탈퇴가 완료되었습니다."));
     }
 }

--- a/src/main/java/Devroup/hidaddy/controller/MessageController.java
+++ b/src/main/java/Devroup/hidaddy/controller/MessageController.java
@@ -27,8 +27,7 @@ public class MessageController {
     @Operation(
             summary = "SMS 메시지 전송",
             description = "로그인된 사용자의 배우자 번호로 SMS 메시지를 전송합니다. "
-                    + "Authorization 헤더에 유효한 Access Token이 필요합니다. <br>"
-                    + "무료 토큰이 15개여서, 다른 플랫폼으로 내부적으로 변경 예정입니다. 해당 API는 유지됩니다."
+                    + "Authorization 헤더에 유효한 Access Token이 필요합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "메시지 전송 성공"),

--- a/src/main/java/Devroup/hidaddy/controller/UserController.java
+++ b/src/main/java/Devroup/hidaddy/controller/UserController.java
@@ -63,19 +63,19 @@ public class UserController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 (로그인 필요)")
     })
-    public ResponseEntity<MessageResponse> changeName(
+    public ResponseEntity<ApiMessageResponse> changeName(
             @RequestBody ChangeUserNameRequest requestDto,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         if (userDetails == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new MessageResponse("인증이 필요합니다."));
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ApiMessageResponse("인증이 필요합니다."));
         }
         if (requestDto == null || requestDto.getUserName() == null || requestDto.getUserName().trim().isEmpty()) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new MessageResponse("이름은 비워둘 수 없습니다."));
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiMessageResponse("이름은 비워둘 수 없습니다."));
         }
 
         userService.changeUserName(userDetails.getUser(), requestDto.getUserName().trim());
-        return ResponseEntity.ok(new MessageResponse("유저 이름 변경 완료"));
+        return ResponseEntity.ok(new ApiMessageResponse("유저 이름 변경 완료"));
     }
 
     // 아기 등록 (튜토리얼 플로우)
@@ -166,7 +166,7 @@ public class UserController {
             @ApiResponse(responseCode = "200", description = "아기 그룹 삭제 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 (로그인 필요)")
     })
-    public ResponseEntity<MessageResponse> deleteBaby(
+    public ResponseEntity<ApiMessageResponse> deleteBaby(
             @PathVariable Long groupId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
@@ -175,7 +175,7 @@ public class UserController {
         }
 
         babyService.deleteBabyGroup(userDetails.getUser(), groupId);
-        return ResponseEntity.ok(new MessageResponse("아기 그룹 삭제 완료"));
+        return ResponseEntity.ok(new ApiMessageResponse("아기 그룹 삭제 완료"));
     }
 
     // 간단 아기 등록 (태명/예정일만)
@@ -246,8 +246,8 @@ public class UserController {
     @PatchMapping("/phone")
     @Operation(
             summary = "사용자 및 파트너 전화번호 등록/수정",
-            description = "로그인된 사용자의 `phone`과 `partnerPhone`을 등록하거나 수정합니다. "
-                    + "요청 시 JSON 바디로 `phone`, `partnerPhone` 값을 전달하며, "
+            description = "로그인된 사용자의 `partnerPhone`을 등록하거나 수정합니다. "
+                    + "요청 시 JSON 바디로 `partnerPhone` 값을 전달하며, "
                     + "둘 중 하나만 보내도 되고, 보내지 않은 필드는 기존 값을 유지합니다. "
                     + "Authorization 헤더에 유효한 Access Token이 필요합니다."
     )
@@ -257,7 +257,7 @@ public class UserController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자 (로그인 필요)"),
             @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없음")
     })
-    public ResponseEntity<MessageResponse> patchPhoneNumbers(
+    public ResponseEntity<ApiMessageResponse> patchPhoneNumbers(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestBody PhoneUpdateRequest dto
     ) {
@@ -265,6 +265,6 @@ public class UserController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         userService.updatePhoneNumbers(userDetails.getUser().getId(), dto);
-        return ResponseEntity.ok(new MessageResponse("전화번호가 성공적으로 변경되었습니다."));
+        return ResponseEntity.ok(new ApiMessageResponse("전화번호가 성공적으로 변경되었습니다."));
     }
 }

--- a/src/main/java/Devroup/hidaddy/dto/user/ApiMessageResponse.java
+++ b/src/main/java/Devroup/hidaddy/dto/user/ApiMessageResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @Schema(description = "기본 메시지 응답 DTO")
-public class MessageResponse {
+public class ApiMessageResponse {
 
     private String message;
 }

--- a/src/main/java/Devroup/hidaddy/dto/user/BabyBasicRegisterListRequest.java
+++ b/src/main/java/Devroup/hidaddy/dto/user/BabyBasicRegisterListRequest.java
@@ -1,11 +1,9 @@
 package Devroup.hidaddy.dto.user;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import java.util.List;
 
 @Getter
-@NoArgsConstructor
 public class BabyBasicRegisterListRequest {
     private List<BabyRegisterRequest> babies;
 }

--- a/src/main/java/Devroup/hidaddy/dto/user/BabyGroupResponse.java
+++ b/src/main/java/Devroup/hidaddy/dto/user/BabyGroupResponse.java
@@ -3,7 +3,6 @@ package Devroup.hidaddy.dto.user;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Getter

--- a/src/main/java/Devroup/hidaddy/dto/user/BabyRegisterListRequest.java
+++ b/src/main/java/Devroup/hidaddy/dto/user/BabyRegisterListRequest.java
@@ -1,12 +1,9 @@
 package Devroup.hidaddy.dto.user;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import java.util.List;
 
 @Getter
-@NoArgsConstructor
 public class BabyRegisterListRequest {
     private String userName;
     private List<BabyRegisterRequest> babies;

--- a/src/main/java/Devroup/hidaddy/dto/user/BabyRegisterRequest.java
+++ b/src/main/java/Devroup/hidaddy/dto/user/BabyRegisterRequest.java
@@ -1,14 +1,10 @@
 package Devroup.hidaddy.dto.user;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import java.time.LocalDate;
 
 @Getter
-@NoArgsConstructor
 public class BabyRegisterRequest {
     private String babyName;
 

--- a/src/main/java/Devroup/hidaddy/dto/user/PhoneUpdateRequest.java
+++ b/src/main/java/Devroup/hidaddy/dto/user/PhoneUpdateRequest.java
@@ -2,14 +2,9 @@ package Devroup.hidaddy.dto.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class PhoneUpdateRequest {
-    @Schema(description = "전화번호 (000-0000-0000 형식)", example = "010-1234-5678")
-    private String phone;
-
     @Schema(description = "와이프 전화번호 (000-0000-0000 형식)", example = "010-1234-5678")
     private String partnerPhone;
 }

--- a/src/main/java/Devroup/hidaddy/dto/user/UserResponse.java
+++ b/src/main/java/Devroup/hidaddy/dto/user/UserResponse.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 public class UserResponse {
     private Long userId;
     private String userName;
-    private String phone;
     private String partnerPhone;
     private String profileImageUrl;
     private String email;
@@ -16,7 +15,6 @@ public class UserResponse {
         this.userId = user.getId();
         this.userName = user.getName();
         this.partnerPhone = user.getPartnerPhone();
-        this.phone = user.getPhone();
         this.profileImageUrl = user.getProfileImageUrl();
         this.email = user.getEmail();  // BabyRepository로 가져온 이름
     }

--- a/src/main/java/Devroup/hidaddy/service/UserService.java
+++ b/src/main/java/Devroup/hidaddy/service/UserService.java
@@ -232,9 +232,6 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-        if (dto.getPhone() != null) {
-            user.setPhone(dto.getPhone());
-        }
         if (dto.getPartnerPhone() != null) {
             user.setPartnerPhone(dto.getPartnerPhone());
         }


### PR DESCRIPTION
- /api/user/phone 엔드포인트에서 사용자 본인 번호 제거, partnerPhone만 처리
- PhoneUpdateRequest에서 phone 필드 제거
- 불필요 주석·어노테이션 삭제